### PR TITLE
Use HOSTNAME env variable instead of HOST

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -42,7 +42,7 @@ if [ "$1" = 'cassandra' ]; then
   # If multiple broadcast addresses were past in, then assume we're running as a stateful set
   # and use the hostname to determine the index.
   if [ "$CASSANDRA_BROADCAST_ADDRESS_LIST" ]; then
-    index=$((${HOST: -1}+1))
+    index=$((${HOSTNAME: -1}+1))
     myAddress=`echo "$CASSANDRA_BROADCAST_ADDRESS_LIST" | sed "$index q;d"`
     if [ "$myAddress" ]; then
       CASSANDRA_BROADCAST_ADDRESS="$myAddress"


### PR DESCRIPTION
Hello,

Thanks for your interesting post on medium!

I tried this setup (without helm - using direct yaml) because it's the first I see addressing the issue I get of keeping a "fixed IP address" for a given cassandra node, so that cassandra does not get lost when seeing new IP addresses thinking it's new nodes, when it's actually the same statefulset pod with the same volume...

I ran it with a replica of 3, and I see this `index` value is always set to 1 because the `HOST` env variable is empty. As a result, all nodes think they have the same IP (the 1st one).

Were you able to run this exact chart with multiple replicas and have each pod get its correct external IP ?

I suggest getting the hostname from the `HOSTNAME` env variable that is set, if you can confirm the bug on your side.

Note: I am not running it in IBM either